### PR TITLE
Tolerate leading zeros in numeric color parameters

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -2,9 +2,10 @@ package ansi
 
 import (
 	"fmt"
-	"github.com/rivo/uniseg"
 	"strconv"
 	"strings"
+
+	"github.com/rivo/uniseg"
 )
 
 // TextStyle is a type representing the
@@ -321,6 +322,7 @@ func Parse(input string, options ...ParseOption) ([]*StyledText, error) {
 				skip--
 				continue
 			}
+			param = stripLeadingZeros(param)
 			switch param {
 			case "0", "":
 				colourMap = ColourMap["Regular"]
@@ -369,9 +371,10 @@ func Parse(input string, options ...ParseOption) ([]*StyledText, error) {
 					return nil, invalid
 				}
 				// 256 colours
-				if params[index+1] == "5" {
+				param1 := stripLeadingZeros(params[index+1])
+				if param1 == "5" {
 					skip = 2
-					colIndexText := params[index+2]
+					colIndexText := stripLeadingZeros(params[index+2])
 					colIndex, err := strconv.Atoi(colIndexText)
 					if err != nil {
 						return nil, invalid256ColSequence
@@ -391,7 +394,7 @@ func Parse(input string, options ...ParseOption) ([]*StyledText, error) {
 				if len(params)-index < 5 {
 					return nil, invalidTrueColorSequence
 				}
-				if params[index+1] != "2" {
+				if param1 != "2" {
 					return nil, invalidTrueColorSequence
 				}
 				var r, g, b uint8
@@ -463,6 +466,13 @@ func Parse(input string, options ...ParseOption) ([]*StyledText, error) {
 			}
 		}
 	}
+}
+
+func stripLeadingZeros(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	return strings.TrimLeft(s, "0")
 }
 
 // HasEscapeCodes tests that input has escape codes.

--- a/ansi_test.go
+++ b/ansi_test.go
@@ -687,3 +687,25 @@ func TestLength(t *testing.T) {
 		})
 	}
 }
+
+func TestStripLeadingZeros(t *testing.T) {
+	is2 := is.New(t)
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+	}{
+		{"Blank", "", ""},
+		{"One rune not 0", "4", "4"},
+		{"Only 0", "0", "0"},
+		{"Multi-digit non-0", "35", "35"},
+		{"Two-digit leading 0", "05", "5"},
+		{"Three-digit leading 0", "045", "45"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripLeadingZeros(tt.input)
+			is2.Equal(got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
This change allows leading zeros in parameters. I.e. it will accept `ESC [032m` as if it were `ESC [32m` .

This is mostly to support https://github.com/aybabtme/rgbterm which uses the sequence `ESC [0;00m` to reset the terminal colors to default:

https://github.com/aybabtme/rgbterm/blob/cc83f3b3ce5911279513a46d6d3316d67bedaa54/rgbterm.go#L36

Really, the change could just as easily be made in rgbterm. But it seems like most terminals support having that leading zero (since rgbterm works in them), so it's likely that leading zeros would show up in other places like other colorizing implementations or people's scripts. 